### PR TITLE
Update go-ircevo to v1.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.2
 require (
 	github.com/fatih/color v1.17.0
 	github.com/gliderlabs/ssh v0.3.5
-	github.com/kofany/go-ircevo v1.2.1
+	github.com/kofany/go-ircevo v1.2.2
 	github.com/sevlyar/go-daemon v0.1.6
 	golang.org/x/crypto v0.39.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/h12w/go-socks5 v0.0.0-20200522160539-76189e178364 h1:5XxdakFhqd9dnXoA
 github.com/h12w/go-socks5 v0.0.0-20200522160539-76189e178364/go.mod h1:eDJQioIyy4Yn3MVivT7rv/39gAJTrA7lgmYr8EW950c=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
-github.com/kofany/go-ircevo v1.2.1 h1:6IOT2MthZLbaHwbKT78hOvtuBi/6kEyy2H2vwbBJNK0=
-github.com/kofany/go-ircevo v1.2.1/go.mod h1:cHYwmtY1kQT/ha+t1P3qvu1oDrhxqUfkM0dlktsD51w=
+github.com/kofany/go-ircevo v1.2.2 h1:CqBrm6ZBfQkqtVEFShSPBQHBtiFjwNstRS2eOo++sCw=
+github.com/kofany/go-ircevo v1.2.2/go.mod h1:cHYwmtY1kQT/ha+t1P3qvu1oDrhxqUfkM0dlktsD51w=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=


### PR DESCRIPTION
Update `go-ircevo` dependency to v1.2.2.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4ffa531-6e6e-4c6d-a377-db6977364427">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a4ffa531-6e6e-4c6d-a377-db6977364427">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

